### PR TITLE
Changed calculations so distance down page is taken into account

### DIFF
--- a/src/components/ScrollParallax.vue
+++ b/src/components/ScrollParallax.vue
@@ -1,86 +1,86 @@
 <template>
-  <div ref="scrollParallax">
-    <slot>
-    </slot>
-  </div>
+	<div ref="scrollParallax">
+		<div ref="scrollParallaxChild">
+			<slot> </slot>
+		</div>
+	</div>
 </template>
 
 <script>
-  export default {
-    name: 'ScrollParallax',
-    props: {
-      speed: {
-        type: Number,
-        required: true,
-        default: 0.15
-      },
-      down: {
-        type: Boolean,
-        default: false,
-        required: false
-      },
-      up: {
-        type: Boolean,
-        default: true,
-        required: false
-      },
-      right: {
-        type: Boolean,
-        default: true,
-        required: false
-      },
-      left: {
-        type: Boolean,
-        default: false,
-        requiredequired: false
-      },
-      direction: {
-        type: String,
-        default: 'y',
-        required: false
-      }
-    },
-    data() {
-      return {
-        el: null,
-        axes: null,
-        speedCoeff: null
-      }
-    },
-    methods: {
-      loadParallax() {
-        this.initDirection();
-        this.el = this.$refs.scrollParallax;
-        // const speedCoeff = this.down ? -this.speed : this.speed;
-        window.addEventListener('scroll', () => {
-          this.el.style.transform = `translate${this.axes}(${window.pageYOffset * this.speedCoeff}px)`;
-        });
-      },
-      initDirection() {
-        if (this.direction === 'x') {
-          this.axes = 'X';
-          if (this.left) {
-            this.speedCoeff = -this.speed;
-          }
-          else {
-            this.speedCoeff = this.speed;
-          }
-        }
-        else if (this.direction === 'y'){
-          this.axes = 'Y' ;
-          if (this.down) {
-            this.speedCoeff = -this.speed;
-          }
-          else {
-            this.speedCoeff = this.speed;
-          }
-        }
-      }
-    },
-    mounted() {
-      this.loadParallax();
-    }
-  };
+export default {
+	name: 'ScrollParallax',
+	props: {
+		speed: {
+			type: Number,
+			required: true,
+			default: 0.15,
+		},
+		down: {
+			type: Boolean,
+			default: false,
+			required: false,
+		},
+		up: {
+			type: Boolean,
+			default: true,
+			required: false,
+		},
+		right: {
+			type: Boolean,
+			default: true,
+			required: false,
+		},
+		left: {
+			type: Boolean,
+			default: false,
+			requiredequired: false,
+		},
+		direction: {
+			type: String,
+			default: 'y',
+			required: false,
+		},
+	},
+	data() {
+		return {
+			el: null,
+			elChild: null,
+			axes: null,
+			speedCoeff: null,
+		}
+	},
+	methods: {
+		loadParallax() {
+			this.initDirection()
+			this.el = this.$refs.scrollParallax
+			this.elChild = this.$refs.scrollParallaxChild
+			window.addEventListener('scroll', this.update)
+		},
+		update() {
+			let rect = this.el.getBoundingClientRect()
+			let elY = rect.y + rect.height / 2 - window.innerHeight / 2 // how far down the page the center of the element is
+			this.elChild.style.transform = `translate${this.axes}(${elY * this.speedCoeff}px)`
+		},
+		initDirection() {
+			if (this.direction === 'x') {
+				this.axes = 'X'
+				if (this.left) {
+					this.speedCoeff = -this.speed
+				} else {
+					this.speedCoeff = this.speed
+				}
+			} else if (this.direction === 'y') {
+				this.axes = 'Y'
+				if (this.down) {
+					this.speedCoeff = -this.speed
+				} else {
+					this.speedCoeff = this.speed
+				}
+			}
+		},
+	},
+	mounted() {
+		this.loadParallax()
+	},
+}
 </script>
-
-

--- a/src/components/ScrollParallax.vue
+++ b/src/components/ScrollParallax.vue
@@ -1,86 +1,86 @@
 <template>
-	<div ref="scrollParallax">
-		<div ref="scrollParallaxChild">
-			<slot> </slot>
-		</div>
-	</div>
+  <div ref="scrollParallax">
+    <div ref="scrollParallaxChild">
+      <slot> </slot>
+    </div>
+  </div>
 </template>
 
 <script>
 export default {
-	name: 'ScrollParallax',
-	props: {
-		speed: {
-			type: Number,
-			required: true,
-			default: 0.15,
-		},
-		down: {
-			type: Boolean,
-			default: false,
-			required: false,
-		},
-		up: {
-			type: Boolean,
-			default: true,
-			required: false,
-		},
-		right: {
-			type: Boolean,
-			default: true,
-			required: false,
-		},
-		left: {
-			type: Boolean,
-			default: false,
-			requiredequired: false,
-		},
-		direction: {
-			type: String,
-			default: 'y',
-			required: false,
-		},
-	},
-	data() {
-		return {
-			el: null,
-			elChild: null,
-			axes: null,
-			speedCoeff: null,
-		}
-	},
-	methods: {
-		loadParallax() {
-			this.initDirection()
-			this.el = this.$refs.scrollParallax
-			this.elChild = this.$refs.scrollParallaxChild
-			window.addEventListener('scroll', this.update)
-		},
-		update() {
-			let rect = this.el.getBoundingClientRect()
-			let elY = rect.y + rect.height / 2 - window.innerHeight / 2 // how far down the page the center of the element is
-			this.elChild.style.transform = `translate${this.axes}(${elY * this.speedCoeff}px)`
-		},
-		initDirection() {
-			if (this.direction === 'x') {
-				this.axes = 'X'
-				if (this.left) {
-					this.speedCoeff = -this.speed
-				} else {
-					this.speedCoeff = this.speed
-				}
-			} else if (this.direction === 'y') {
-				this.axes = 'Y'
-				if (this.down) {
-					this.speedCoeff = -this.speed
-				} else {
-					this.speedCoeff = this.speed
-				}
-			}
-		},
-	},
-	mounted() {
-		this.loadParallax()
-	},
+  name: 'ScrollParallax',
+  props: {
+    speed: {
+      type: Number,
+      required: true,
+      default: 0.15,
+    },
+    down: {
+      type: Boolean,
+      default: false,
+      required: false,
+    },
+    up: {
+      type: Boolean,
+      default: true,
+      required: false,
+    },
+    right: {
+      type: Boolean,
+      default: true,
+      required: false,
+    },
+    left: {
+      type: Boolean,
+      default: false,
+      requiredequired: false,
+    },
+    direction: {
+      type: String,
+      default: 'y',
+      required: false,
+    },
+  },
+  data() {
+    return {
+      el: null,
+      elChild: null,
+      axes: null,
+      speedCoeff: null,
+    }
+  },
+  methods: {
+    loadParallax() {
+      this.initDirection()
+      this.el = this.$refs.scrollParallax
+      this.elChild = this.$refs.scrollParallaxChild
+      window.addEventListener('scroll', this.update)
+    },
+    update() {
+      let rect = this.el.getBoundingClientRect()
+      let elY = rect.y + rect.height / 2 - window.innerHeight / 2 // how far down the page the center of the element is
+      this.elChild.style.transform = `translate${this.axes}(${elY * this.speedCoeff}px)`
+    },
+    initDirection() {
+      if (this.direction === 'x') {
+        this.axes = 'X'
+        if (this.left) {
+          this.speedCoeff = -this.speed
+        } else {
+          this.speedCoeff = this.speed
+        }
+      } else if (this.direction === 'y') {
+        this.axes = 'Y'
+        if (this.down) {
+          this.speedCoeff = -this.speed
+        } else {
+          this.speedCoeff = this.speed
+        }
+      }
+    },
+  },
+  mounted() {
+    this.loadParallax()
+  },
 }
 </script>


### PR DESCRIPTION
I liked your component, but found that if the element was far down the page, it would be moved really far already by the time the user scrolled down to it. The further down the page it is, the more dramatic the discrepancy. 
I altered the math so that it takes into account how far down the page the element is. I.e. The element will appear in its natural css position when you've scrolled it to the center of the viewport. Distance scrolled up or down _from that point_ (rather than distance scrolled down from the top of the page) controls the parallax effect.